### PR TITLE
update ElsuFoundation dependency to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
 		<dependency>
 			<groupId>elsu.foundation</groupId>
 			<artifactId>ElsuFoundation</artifactId>
-			<version>1.0.0</version>
+			<version>1.4.0</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->


### PR DESCRIPTION
Looks like 1.4.0 is the latest available at https://github.com/ssdhaliwal/ElsuFoundation/tags . I also don't see a 1.0.0 release there.